### PR TITLE
Working around oauth bug.

### DIFF
--- a/lib/Evernote/Client.php
+++ b/lib/Evernote/Client.php
@@ -45,14 +45,14 @@ class Client
     {
         $oauth = new \OAuth($this->consumerKey, $this->consumerSecret);
 
-        return $oauth->getRequestToken($this->getEndpoint('oauth'), $callbackUrl);
+        return $oauth->getRequestToken($this->getEndpoint('oauth'), $callbackUrl, 'GET');
     }
 
     public function getAccessToken($oauthToken, $oauthTokenSecret, $oauthVerifier)
     {
         $oauth = new \OAuth($this->consumerKey, $this->consumerSecret);
         $oauth->setToken($oauthToken, $oauthTokenSecret);
-        $accessToken= $oauth->getAccessToken($this->getEndpoint('oauth'), null, $oauthVerifier);
+        $accessToken= $oauth->getAccessToken($this->getEndpoint('oauth'), null, $oauthVerifier, 'GET');
 
         $this->token = $accessToken['oauth_token'];
 


### PR DESCRIPTION
Making the oauth callback POST results in a 411 error. This is due to the fact that the length header isn't being set as per the PHP oauth docs. Posting without that header used to work for us, and still works in sandbox mode, but no longer works with sandbox mode set to false. Changing the requests to GET worked for us, but you may want to fix this in another way. Submitting the pull request in case this solution is acceptable to you.